### PR TITLE
Fix Python 3.11 issues

### DIFF
--- a/storm/__init__.py
+++ b/storm/__init__.py
@@ -5,6 +5,12 @@ from __future__ import print_function
 from operator import itemgetter
 import re
 from shutil import copyfile
+import warnings
+try:
+    from cryptography.utils import CryptographyDeprecationWarning
+    warnings.filterwarnings("ignore", category=CryptographyDeprecationWarning)
+except Exception:
+    pass
 
 from .parsers.ssh_config_parser import ConfigParser
 from .defaults import get_default

--- a/storm/__main__.py
+++ b/storm/__main__.py
@@ -15,6 +15,10 @@ from storm.utils import (get_formatted_message, colored)
 from storm.kommandr import *
 from storm.defaults import get_default
 from storm import __version__
+try:
+    from collections.abc import Sequence
+except ImportError:  # Python 2 fallback
+    from collections import Sequence
 
 import sys
 
@@ -224,7 +228,7 @@ def list(config=None):
                                 result += " {0}".format(custom_options)
                             extra = True
 
-                            if isinstance(value, collections.Sequence):
+                            if isinstance(value, Sequence):
                                 if isinstance(value, builtins.list):
                                     value = ",".join(value)
                                     

--- a/storm/kommandr.py
+++ b/storm/kommandr.py
@@ -146,7 +146,10 @@ class prog(object):
         subparser = self.subparsers.add_parser(name or func.__name__,
                                                aliases=aliases,
                                                help=func_help)
-        spec = inspect.getargspec(func)
+        try:
+            spec = inspect.getfullargspec(func)
+        except AttributeError:
+            spec = inspect.getargspec(func)
         opts = reversed(list(izip_longest(reversed(spec.args or []),
                                           reversed(spec.defaults or []),
                                           fillvalue=self._POSITIONAL())))


### PR DESCRIPTION
## Summary
- handle missing `inspect.getargspec` in Python 3.11
- use `collections.abc.Sequence` for newer Python versions
- silence cryptography deprecation warnings during import

## Testing
- `python tests.py`

------
https://chatgpt.com/codex/tasks/task_b_6859424073088321a02d2c4f5ecef6d7