### PR TITLE
Fix grammar in docs/installing.rst

### DIFF
--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -13,7 +13,7 @@ or if you like 90s:
 
     $ [sudo] easy_install stormssh
 
-or download and add storm directory to the your `$PATH`. E.g.
+or download and add storm directory to your `$PATH`. E.g.
 
 .. code-block:: bash
 


### PR DESCRIPTION
## Summary
- fix small grammar typo in install guide

## Testing
- `pytest -q`
- `nosetests -s` *(fails: SyntaxError in nose)*

------
https://chatgpt.com/codex/tasks/task_b_685945ebf8148321ac1234398ff1f0d0