### PR TITLE
Fix backup command docstring

### DIFF
--- a/storm/__main__.py
+++ b/storm/__main__.py
@@ -298,7 +298,7 @@ def delete_all(config=None):
 @command('backup')
 def backup(target_file, config=None):
     """
-    Backups the main ssh configuration into target file.
+    Backs up the main SSH configuration to the target file.
     """
     storm_ = get_storm_instance(config)
     try:


### PR DESCRIPTION
## Summary
- update the docstring for the backup command

## Testing
- `python tests.py -v` *(fails: FileNotFoundError for `storm` command)*

------
https://chatgpt.com/codex/tasks/task_b_685948f374f083218a3883265943e75e