### PR TITLE
Fix test for invalid worker edit

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -258,7 +258,8 @@ class StormCliTestCase(unittest.TestCase):
             self.assertIn(b"alphauser", content)
 
         out, err, rc = self.run_cmd("edit worker  {0}".format(self.config_arg))
-
+        self.assertNotEqual(rc, 0)
+        self.assertIn(b"error", err)
 
     def test_update_invalid_regex(self):
 


### PR DESCRIPTION
## Summary
- ensure `edit worker` command without args returns an error

## Testing
- `python tests.py`

------
https://chatgpt.com/codex/tasks/task_b_6859498ffd508321b0b12a97753beba4