### PR TITLE
Update tox setup for modern versions

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 pytest
 pytest-cov
 coverage>=7
-tox
+tox>=4

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,11 @@
 [tox]
-envlist = py27,py32,py33,py34
-skipsdist = True
+envlist = py310, py311, py312
+skip_missing_interpreters = true
 
 [testenv]
+skip_install = true
 commands =
  pip install -e .
  pytest
 deps =
  -rrequirements-dev.txt
-
-[testenv:py26]
-deps =
- {[testenv]deps}
- unittest2


### PR DESCRIPTION
## Summary
- upgrade to `tox>=4`
- test on maintained Python releases
- drop outdated config options

## Testing
- `pytest -q`
- `tox -q -e py311` *(fails: no tests ran)*

------
https://chatgpt.com/codex/tasks/task_b_685951266e2483219cda4f73109f7291