### PR TITLE
Update Python compatibility classifiers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,11 @@
 language: python
 python:
-  - "2.7"
-  - "3.2"
-  - "3.3"
-  - "3.4"
-  - "3.5"
-  - "3.6"
-  - "3.6-dev"
-  - "3.7-dev"
-  - "nightly"
+  - "3.8"
+  - "3.9"
+  - "3.10"
+  - "3.11"
+  - "3.12"
 install:
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2; fi
   - pip install -e .
   - pip install -r requirements-dev.txt
 script: pytest -v

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,11 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3 :: Only',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'License :: OSI Approved :: MIT License',
         'Topic :: System :: Systems Administration',
     ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py310, py311, py312
+envlist = py38, py39, py310, py311, py312
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
## Summary
- declare supported Python versions 3.8+
- run tox on maintained versions only
- update Travis CI matrix for modern Pythons

## Testing
- `pytest -q tests.py`

------
https://chatgpt.com/codex/tasks/task_b_685a4bed42408321a1c696a8e90e7e5c