### PR TITLE
Update Vagrant setup for Python 3

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
+set -e
 
-# setup pip
+# install Python 3 and pip
 apt-get update
-apt-get install -y python3-dev
-apt-get install -y python3-pip
+apt-get install -y python3 python3-dev python3-pip
 
 # install storm ssh dependencies
-pip3 install -e /vagrant
+python3 -m pip install -e /vagrant
 
-# setup pth file
+# setup pth file using the Python 3 site-packages path
 SITE_PACKAGES=$(python3 -c 'import site; print(site.getsitepackages()[0])')
 echo /vagrant > "$SITE_PACKAGES"/storm.pth
 


### PR DESCRIPTION
## Summary
- install Python 3 and pip inside `scripts/setup.sh`
- use `python3 -m pip` and site-packages path from Python 3
- fail fast in the provisioning script

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_685a4c6ce4ac8321b9533ea3aaa1a312