### PR TITLE
Update Vagrant base box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,9 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "hashicorp/precise32"
+  # Use a recent Ubuntu LTS image
+  config.vm.box = "ubuntu/focal64"
   
+  # Provision using the Python 3 setup script
   config.vm.provision "shell", path: "scripts/setup.sh"
 end


### PR DESCRIPTION
## Summary
- use ubuntu/focal64 instead of the legacy precise32 box
- clarify provisioning comment

## Testing
- `tox -q` *(fails: no tests ran)*

------
https://chatgpt.com/codex/tasks/task_b_685a4d37cc388321a31c567178a7c610