### PR TITLE
Improve colored output for search command

### DIFF
--- a/storm/__main__.py
+++ b/storm/__main__.py
@@ -12,6 +12,7 @@ except ImportError:
 from storm import Storm
 from storm.parsers.ssh_uri_parser import parse
 from storm.utils import (get_formatted_message, colored)
+import re
 from storm.kommandr import *
 from storm.defaults import get_default
 from storm import __version__
@@ -274,9 +275,36 @@ def search(search_text, config=None):
             print ('no results found.')
 
         if len(results) > 0:
-            message = 'Listing results for {0}:\n'.format(search_text)
-            message += "".join(results)
-            print(message)
+            message = colored(
+                'Listing results for {0}:'.format(search_text),
+                'white',
+                attrs=["bold", ]
+            ) + "\n\n"
+
+            for res in results:
+                res = res.strip()
+                if '->' in res:
+                    alias, info = [x.strip() for x in res.split('->', 1)]
+                    user_host_port = info
+                    m = re.match(r'([^@]+)@([^:]+):(.*)', user_host_port)
+                    if m:
+                        user, hostname, port = m.groups()
+                        formatted = "    {0} -> {1}@{2}:{3}\n".format(
+                            colored(alias, 'green', attrs=["bold", ]),
+                            colored(user, 'magenta'),
+                            hostname,
+                            colored(port, 'cyan')
+                        )
+                    else:
+                        formatted = "    {0} -> {1}\n".format(
+                            colored(alias, 'green', attrs=["bold", ]),
+                            info,
+                        )
+                else:
+                    formatted = res + "\n"
+                message += formatted
+
+            print(get_formatted_message(message, ""))
     except Exception as error:
         print(get_formatted_message(str(error), 'error'), file=sys.stderr)
         sys.exit(1)

--- a/tests.py
+++ b/tests.py
@@ -286,7 +286,7 @@ class StormCliTestCase(unittest.TestCase):
 
         out, err, rc = self.run_cmd("search aws {0}".format(self.config_arg))
 
-        self.assertTrue(out.startswith(b'Listing results for aws:'))
+        self.assertTrue(out.startswith(b' Listing results for aws:'))
         self.assertIn(b'aws.apache', out)
         self.assertEqual(rc, 0)
 


### PR DESCRIPTION
## Summary
- format `storm search` results like `storm list`
- color usernames and SSH ports in search output
- update tests for new formatting

## Testing
- `python tests.py`

------
https://chatgpt.com/codex/tasks/task_b_685a64e9a9ac8321917578e04d197990