### PR TITLE
Release v0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.8.2] - 2025-06-24
+- Added colored output to ``storm search`` results
+- Merged wildcard SSH config entries in search results
+
 ## [0.8.1] - 2025-06-24
 - Checked for deprecated dependencies and updated to maintained versions
 - Cleaned up setup configuration and pinned compatible library versions

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='stormssh',
-    version='0.8.1',
+    version='0.8.2',
     packages=find_packages(),
     package_data={'storm': ['templates/*.html', 'static/css/*.css',
                             'static/css/themes/storm/*.css', 'static/css/themes/storm/img/*.png',

--- a/storm/__init__.py
+++ b/storm/__init__.py
@@ -16,7 +16,7 @@ from .parsers.ssh_config_parser import ConfigParser
 from .defaults import get_default
 
 
-__version__ = '0.8.1'
+__version__ = '0.8.2'
 
 ERRORS = {
     "already_in": "{0} is already in your sshconfig. "


### PR DESCRIPTION
## Summary
- bump version to 0.8.2
- add changelog entry for colored search results and wildcard merging

## Testing
- `python tests.py`

------
https://chatgpt.com/codex/tasks/task_b_685a757a60c48321ac4a6dd54d8906e9