### PR TITLE
Add GitHub release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+name: Build and Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyinstaller build
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+      - name: Run tests
+        run: pytest
+      - name: Build wheel and sdist
+        run: |
+          python -m build
+      - name: Build binary
+        run: |
+          pyinstaller --onefile storm/__main__.py -n storm
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-files
+          path: |
+            dist/*.whl
+            dist/*.tar.gz
+            dist/storm
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: release-files
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            *.whl
+            *.tar.gz
+            storm


### PR DESCRIPTION
## Summary
- build wheel and PyInstaller binary on tag pushes
- publish artifacts as a GitHub Release
- use v4 actions for core setup

## Testing
- `pytest`
- `python -m build`
- `pyinstaller --onefile storm/__main__.py -n storm`


------
https://chatgpt.com/codex/tasks/task_b_685ce308f45c8321b1124a6f69761859